### PR TITLE
Recursive application of ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ A list of objects describing subdirectories.
 oid: string. # Required. Security principal Object ID in Microsoft Entra ID.
 type: string # Required. Security principal type.
 acl: string 
-scope: string. 
+scope: string
+recursive: bool
 ```
 `oid` string. Required.
 Object ID of the principal (user/group/managed identity/service principal) in Microsoft Entra (former Azure Active Directory).
@@ -204,6 +205,9 @@ e.g.:
 
 `scope` string. Optional
 If set to `default` it will set the specified ACLs as `default ACLs` [MS DOCS: Types of ACLs](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-access-control#types-of-acls). If not present, ACLs will be set as `access ACLs`.
+
+`recursive` bool. Optional
+If set to `True` that ACL will be applied recursively to every subdirectroy and file inside the directory this ACL is to be set on.
 
 #### Special ACLs
 
@@ -243,6 +247,7 @@ They will not be set on any files that had existed in the directories prior to t
 Moreover, any subdirectories that exist in the account but are not specified in the input file remain untouched by `adls-acl`.
 
 Future releases will allow for more control over this behaviour (i.e, updating default ACLs on all files created prior to the change of ACLs).
+
 
 ### Authentication Methods
 

--- a/src/adls_acl/nodes.py
+++ b/src/adls_acl/nodes.py
@@ -8,6 +8,7 @@ class Acl:
     oid: str
     permissions: str
     scope: Optional[str] = None
+    recursive: Optional[bool] = False
 
     @classmethod
     def from_str(cls, acl_str: str):
@@ -23,14 +24,18 @@ class Acl:
     @classmethod
     def from_dict(cls, acl_dict: Dict):
         """Returns an instance of Acl from a dict from yaml input"""
+        recursive = False
+        scope = None
         if "acl" in acl_dict:
             acl = acl_dict["acl"]
         if "scope" in acl_dict:
             scope = acl_dict["scope"]
-        else:
-            scope = None
+        if "recursive" in acl_dict:
+            recursive = acl_dict["recursive"]
 
-        acl = Acl(acl_dict["type"], acl_dict["oid"], acl, scope=scope)
+        acl = Acl(
+            acl_dict["type"], acl_dict["oid"], acl, scope=scope, recursive=recursive
+        )
         return acl
 
     def __str__(self):
@@ -84,6 +89,10 @@ class Acl:
             )
             else False
         )
+
+    def is_recursive(self):
+        """Check if the ACL is supposed to be applied recursively"""
+        return self.recursive
 
     def to_yaml(self):
         """Returns a dict reprentaion"""


### PR DESCRIPTION
This PR enables the recursive update of ACLs. 
ACLs can be marked for recursive application by `recursive: True` in the input file.

Closes #3 